### PR TITLE
Add option to restart CP2K simulations

### DIFF
--- a/bin/charge_density.py
+++ b/bin/charge_density.py
@@ -193,7 +193,10 @@ parser.add_argument('--UseScalapack',
                     action='store_true',
                     required=False,
                     help='Use Scalapack as preferred diagonalization library')
-
+parser.add_argument('--Restart',
+                    action='store_true',
+                    required=False,
+                    help='Restart the simulation from the last saved configuration.')
 
 # Parse the arguments
 arg = parser.parse_args()
@@ -304,8 +307,15 @@ if arg.UseSmearing:
         }
     Force_Eval_Dict["+dft"]['+scf']['added_mos'] = arg.AddedMOs
 
-input = {"+global": Global_Dict, "+force_eval": [Force_Eval_Dict]}
+input_dict = {
+    "+global": Global_Dict,
+    "+force_eval": [Force_Eval_Dict],
+    }
 
+if arg.Restart:
+    input_dict['+ext_restart'] = {
+        "restart_file_name": f"{arg.FrameworkName}-1.restart"
+    }
 generator = CP2KInputGenerator()
 
 with open("simulation_SCF.inp", "w") as fhandle:

--- a/bin/charge_density.py
+++ b/bin/charge_density.py
@@ -316,8 +316,9 @@ if arg.Restart:
     input_dict['+ext_restart'] = {
         "restart_file_name": f"{arg.FrameworkName}-1.restart"
     }
+
 generator = CP2KInputGenerator()
 
 with open("simulation_SCF.inp", "w") as fhandle:
-    for line in generator.line_iter(input):
+    for line in generator.line_iter(input_dict):
         fhandle.write(f"{line}\n")

--- a/bin/parse_optimization.py
+++ b/bin/parse_optimization.py
@@ -81,9 +81,9 @@ if arg.SaveHistory:
                               pbc=(1, 1, 1),
                               positions=StructureList[i][1].T)
 
-        print('Saving structure ' + str(i) + ' of ' + str(len(CellParametersList)))
+        print('Saving structure ' + str(i + 1) + ' of ' + str(len(CellParametersList)))
 
-        tempStructure.write(os.path.join(save_path, arg.FrameworkName + '_Optimization_' + str(i) + '.cif'))
+        tempStructure.write(os.path.join(save_path, arg.FrameworkName + '_Optimization_' + str(i + 1) + '.cif'))
 
 
 # Write the final structure to file

--- a/bin/structure_optimization.py
+++ b/bin/structure_optimization.py
@@ -205,6 +205,10 @@ parser.add_argument('--UseScalapack',
                     action='store_true',
                     required=False,
                     help='Use Scalapack as preferred diagonalization library')
+parser.add_argument('--Restart',
+                    action='store_true',
+                    required=False,
+                    help='Restart the simulation from the last saved configuration.')
 
 # Parse the arguments
 arg = parser.parse_args()
@@ -372,11 +376,18 @@ if arg.OptimizationType == 'geo_opt':
         "rms_force": 0.0007
     }
 
+input_dict = {
+    "+global": Global_Dict,
+    "+force_eval": [Force_Eval_Dict],
+    "+motion": motion_dict}
 
-input = {"+global": Global_Dict, "+force_eval": [Force_Eval_Dict], "+motion": motion_dict}
+if arg.Restart:
+    input_dict['+ext_restart'] = {
+        "restart_file_name": f"{arg.FrameworkName}-1.restart"
+    }
 
 generator = CP2KInputGenerator()
 
 with open("simulation_Optimization.inp", "w") as fhandle:
-    for line in generator.line_iter(input):
+    for line in generator.line_iter(input_dict):
         fhandle.write(f"{line}\n")


### PR DESCRIPTION
This PR adds a option to restart the *charge density* and *structure optimization* calculation as result of #3.

To restart a simulation it is only necessary to add the `--Restart` tag on the input. 


Example:

```
structure_optimization.py --FrameworkName ${FrameworkName} \
                          --Functional "PBE" \
                          --DispersionCorrection "DFTD3(BJ)" \
                          --PWCutoff 1200 \
                          --KeepSymmetry \
                          --BasisSet "TZV2P" \
                          --Restart \
                          ${OutputFolder}
```

**Warning:** To restart a simulation it is necessary that a `{FrameworkName}-1.restart` file exists on the output folder, otherwise CP2K will rise an error since it will not be able to find the restart file and the simulation will fail. 

This PR also fix the naming of the optimization images, that started on 0 while it should start on 1. 

Closes #3 
