### PR TITLE
Save the vibrational modes as cjson

### DIFF
--- a/bin/parse_vibrations.py
+++ b/bin/parse_vibrations.py
@@ -7,7 +7,10 @@ import os
 import argparse
 import numpy as np
 
-from modules.calculate_properties import get_vibrational_data, lorentzian, saveVibrationalVectors
+from modules.calculate_properties import (get_vibrational_data,
+                                          lorentzian,
+                                          saveVibrationalVectors,
+                                          saveChemicalJSON)
 
 # Required parameters
 parser = argparse.ArgumentParser(description='Create the Chargemol simulation input.')
@@ -64,5 +67,9 @@ np.savetxt(os.path.join(arg.output_folder, f'{arg.FrameworkName}_RAMAN_IR_Curve.
            header='Frequency (cm-1), IR Intensity (km/mol), Raman Intensity (A2/amu)',
            delimiter=',')
 
+# Save the vibrations as cjson file
+saveChemicalJSON(arg.output_folder, arg.FrameworkName)
+
+# Save the vibrational modes as AXSF files
 if arg.SaveVibrations:
-    saveVibrationalVectors(arg.FrameworkName, arg.output_folder)
+    saveVibrationalVectors(arg.output_folder, arg.FrameworkName)


### PR DESCRIPTION
This PR adds the capability of saving the vibrational modes as a `ChemicalJSON` file. This format is maintained by the [Open Chemistry Project](https://www.openchemistry.org/) and is compatible with visualization software's such as [Avogadro 2](https://www.openchemistry.org/projects/avogadro2/). 

The structure, vibrational modes, IV/Raman intensities are stored in a `.cjson` file that can be easily stored in databases and shared with the community.

For a `JSON` schema of this format please see https://github.com/OpenChemistry/chemicaljson