### PR TITLE
Calculate charge density surface

### DIFF
--- a/bin/charge_density.py
+++ b/bin/charge_density.py
@@ -318,7 +318,7 @@ if arg.WriteDensity:
 
 if arg.WriteHartreePotential:
     Force_Eval_Dict["+dft"]["+print"]['+v_hartree_cube'] = {
-        "filename": "electronstatic_potential",
+        "filename": "electrostatic_potential",
         "stride": 1
         }
 

--- a/bin/charge_density.py
+++ b/bin/charge_density.py
@@ -197,6 +197,10 @@ parser.add_argument('--WriteDensity',
                     action='store_true',
                     required=False,
                     help='Write the electronic density in cube format.')
+parser.add_argument('--WriteHartreePotential',
+                    action='store_true',
+                    required=False,
+                    help='Write the electrostatic potential in cube format.')
 parser.add_argument('--WriteMO',
                     action='store_true',
                     required=False,
@@ -309,6 +313,12 @@ Force_Eval_Dict = {
 if arg.WriteDensity:
     Force_Eval_Dict["+dft"]["+print"]['+e_density_cube'] = {
         "filename": "valence_density",
+        "stride": 1
+        }
+
+if arg.WriteHartreePotential:
+    Force_Eval_Dict["+dft"]["+print"]['+v_hartree_cube'] = {
+        "filename": "electronstatic_potential",
         "stride": 1
         }
 


### PR DESCRIPTION
This PR adds the new tag `--WriteHartreePotential` to the `charge_density.py` script, allowing the calculation of the electrostatic potential surface (Hartree Potential) for a structure, as exemplified by the image below:

![surface](https://github.com/neumannrf/electronic-structure-experiment/assets/33868364/d9a48097-04f0-43e9-baee-58efca48894f)
