### PR TITLE
Add module to convert files

### DIFF
--- a/bin/convert_file.py
+++ b/bin/convert_file.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env -S python -B
 
-# Copyright IBM Corp. 2023
 # SPDX-License-Identifier: Apache2.0
 
 import argparse

--- a/bin/convert_file.py
+++ b/bin/convert_file.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env -S python -B
+
+# Copyright IBM Corp. 2023
+# SPDX-License-Identifier: Apache2.0
+
+import argparse
+
+from modules.io_files import (readCIF, saveCIF,
+                              readChemicalJSON, saveChemicalJSON,
+                              readGJF, saveGJF,
+                              readXSF, saveXSF)
+
+# Required parameters
+parser = argparse.ArgumentParser(description='Create the CP2K simulation input.')
+parser.add_argument('output_folder',
+                    type=str,
+                    action='store',
+                    metavar='OUTPUT_FOLDER',
+                    help='Directory for storing output files.')
+parser.add_argument('--FrameworkName',
+                    type=str,
+                    required=True,
+                    action='store',
+                    metavar='FRAMEWORK_NAME',
+                    help='Name of the CIF file describing the nanoporous material structure.')
+parser.add_argument('--InputFormat',
+                    type=str,
+                    required=True,
+                    choices=['cif', 'cjson', 'xsf', 'gjf'],
+                    action='store',
+                    metavar='INPUT_FORMAT',
+                    help='Format of the input file.')
+parser.add_argument('--OutputFormat',
+                    type=str,
+                    required=True,
+                    action='store',
+                    choices=['cif', 'cjson', 'xsf', 'gjf'],
+                    metavar='OUTPUT_FORMAT',
+                    help='Format of the output file.')
+parser.add_argument('--ChargeType',
+                    type=str,
+                    default='none',
+                    action='store',
+                    metavar='CHARGE_TYPE',
+                    help='Type of partial charges.')
+
+# Parse the arguments
+arg = parser.parse_args()
+
+# Dictionary containing the function to read files
+read_dict = {
+    'cif': readCIF,
+    'gjf': readGJF,
+    'cjson': readChemicalJSON,
+    'xsf': readXSF,
+}
+
+# Dictionary containing the function to save files
+save_dict = {
+    'cif': saveCIF,
+    'gjf': saveGJF,
+    'cjson': saveChemicalJSON,
+    'xsf': saveXSF,
+}
+
+CellParameters, labels, frac_x, frac_y, frac_z, charges, charge_type = read_dict[arg.InputFormat](arg.FrameworkName)
+
+save_dict[arg.OutputFormat](FrameworkName=arg.FrameworkName,
+                            CellParameters=CellParameters,
+                            labels=labels,
+                            frac_x=frac_x,
+                            frac_y=frac_y,
+                            frac_z=frac_z,
+                            charges=charges,
+                            charge_type=arg.ChargeType,
+                            OutputFolder=arg.output_folder)

--- a/bin/convert_file.py
+++ b/bin/convert_file.py
@@ -63,7 +63,8 @@ save_dict = {
     'xsf': saveXSF,
 }
 
-CellParameters, labels, frac_x, frac_y, frac_z, charges, charge_type = read_dict[arg.InputFormat](arg.FrameworkName)
+CellParameters, labels, frac_x, frac_y, frac_z, charges, charge_type = read_dict[arg.InputFormat](arg.FrameworkName,
+                                                                                                  arg.output_folder)
 
 save_dict[arg.OutputFormat](FrameworkName=arg.FrameworkName,
                             CellParameters=CellParameters,

--- a/bin/modules/io_files.py
+++ b/bin/modules/io_files.py
@@ -1,0 +1,558 @@
+#!/usr/bin/env -S python -B
+
+# Copyright IBM Corp. 2023
+# SPDX-License-Identifier: Apache2.0
+
+import os
+import json
+import gemmi
+
+import numpy as np
+from textwrap import dedent
+
+from ase.cell import Cell
+
+from modules.atom_data import ATOMIC_NUMBER
+from modules.calculate_properties import get_MoldenData, get_vibrational_data, get_CellParameters
+
+
+def readChemicalJSON(FrameworkName: str, OutputFolder: str = '.', **kwargs):
+    """
+    Read the chemical JSON file.
+
+    Parameters
+    ----------
+    FrameworkName : str
+        Name of the framework.
+    OutputFolder : str
+        Path to the output folder. Default: `.`
+
+    A chargeType can be passed as kwargs to read the charges from the cjson file.
+    """
+
+    # Read the cif file and get the lattice parameters and atomic positions
+    cjson_filename = os.path.join(OutputFolder, FrameworkName + '.cjson')
+
+    with open(cjson_filename, 'r') as f:
+        ChemJSON = json.load(f)
+
+    # Get the cell parameters from cif file
+    if 'a' in ChemJSON['unitCell']:
+        CellParameters = [ChemJSON['unitCell']['a'],
+                          ChemJSON['unitCell']['b'],
+                          ChemJSON['unitCell']['c'],
+                          ChemJSON['unitCell']['alpha'],
+                          ChemJSON['unitCell']['beta'],
+                          ChemJSON['unitCell']['gamma']]
+
+    elif 'cellVectors' in ChemJSON['unitCell']:
+        CellMatrix = ChemJSON['unitCell']['cellVectors']
+        aseCell = Cell.frommatrix(CellMatrix)
+        CellParameters = aseCell.cellpar()
+
+    else:
+        print('Could not find the cell parameters in the cjson file.')
+        CellParameters = None
+
+    # Get the atomic labels
+    labels = ChemJSON['atoms']['elements']['type']
+
+    # Get the fractional coordinates
+    frac_x = ChemJSON['atoms']['coords']['3dFractional'][0::3]
+    frac_y = ChemJSON['atoms']['coords']['3dFractional'][1::3]
+    frac_z = ChemJSON['atoms']['coords']['3dFractional'][2::3]
+
+    # Get the charges
+    if 'partialCharges' in ChemJSON:
+        # Check if some charge type was passed as kwargs
+        if 'charge_type' in kwargs:
+            chargeType = kwargs['charge_type']
+        else:
+            chargeType = list(ChemJSON['partialCharges'].keys())[0]
+        charges = ChemJSON['partialCharges'][chargeType]
+
+    return CellParameters, labels, frac_x, frac_y, frac_z, charges, chargeType
+
+
+def saveChemicalJSON(FrameworkName: str,
+                     CellParameters: float,
+                     labels: list[str],
+                     frac_x: list[float],
+                     frac_y: list[float],
+                     frac_z: list[float],
+                     charges: list[float] = None,
+                     charge_type: str = 'none',
+                     OutputFolder: str = '.'):
+    """
+    Save the chemical JSON file.
+
+    Parameters
+    ----------
+    FrameworkName : str
+        Name of the framework.
+    CellParameters : list
+        List of the cell parameters.
+    labels : list
+        List of the atomic labels.
+    frac_x : list
+        List of the atomic positions along the `a` vector.
+    frac_y : list
+        List of the atomic positions along the `b` vector.
+    frac_z : list
+        List of the atomic positions along the `c` vector.
+    charges : list
+        List of the atomic charges.
+    charge_type : str
+        Type of the charges.
+    OutputFolder : str
+        Path to the output folder. Default: `.`
+    """
+
+    # Convert atom_labels to atom_number
+    atom_number = [gemmi.Element(atom).atomic_number for atom in labels]
+
+    # Flatten the atom_pos list
+    atom_pos = np.array([frac_x, frac_y, frac_z]).T
+
+    aseCell = Cell.fromcellpar(CellParameters)
+
+    # Get the cell matrix
+    CellMatrix = aseCell.tolist()
+
+    FracCoords = atom_pos.flatten().tolist()
+    CartCoords = aseCell.cartesian_positions(atom_pos).flatten().tolist()
+
+    formula = ' '.join([f'{atom}{labels.count(atom)}' for atom in set(labels)])
+
+    ChemJSON = {
+        "chemicalJson": 1,
+        "name": FrameworkName,
+        "formula": formula,
+        "unitCell": {
+            "a": CellParameters[0],
+            "b": CellParameters[1],
+            "c": CellParameters[2],
+            "alpha": CellParameters[3],
+            "beta":  CellParameters[4],
+            "gamma": CellParameters[5],
+            "cellVectors": CellMatrix
+        },
+        "atoms": {
+            "elements": {
+                "type": labels,
+                "number": atom_number
+                },
+            "coords": {
+                "3d": CartCoords,
+                "3dFractional": FracCoords
+                }
+        }
+    }
+
+    if charges is not None:
+        ChemJSON["partialCharges"] = {
+            charge_type: charges.tolist()
+        }
+
+    # Save ChemJSON as a json file
+    with open(os.path.join(OutputFolder, f'{FrameworkName}.cjson'), 'w') as f:
+        json.dump(ChemJSON, f, indent=4)
+
+
+def readXSF(FrameworkName: str, OutputFolder: str = '.', **kwargs):
+    """
+    Read the XSF file.
+
+    Parameters
+    ----------
+    FrameworkName : str
+        Name of the framework.
+    OutputFolder : str
+        Path to the output folder. Default: `.`
+    """
+
+    with open(os.path.join(OutputFolder, FrameworkName + '.xsf'), 'r') as f:
+        lines = f.read().splitlines()
+
+    # Get the cell parameters
+    cellMatrix = np.array([lines[2].split(), lines[3].split(), lines[4].split()]).astype(float)
+
+    aseCell = Cell.frommatrix(cellMatrix)
+
+    cellParameters = aseCell.cellpar()
+
+    # Get the atomic labels and positions
+    n_atoms = int(lines[6].split()[0])
+    atoms = lines[7:7 + n_atoms]
+
+    atomLabels = [i.split()[0] for i in atoms]
+
+    cart_x = [float(i.split()[1]) for i in atoms]
+    cart_y = [float(i.split()[2]) for i in atoms]
+    cart_z = [float(i.split()[3]) for i in atoms]
+
+    frac_x, frac_y, frac_z = aseCell.get_fractional_coords(np.array([cart_x, cart_y, cart_z]).T).T
+
+    return cellParameters, atomLabels, frac_x, frac_y, frac_z, None, None
+
+
+def saveXSF(FrameworkName: str,
+            CellParameters: float,
+            labels: list[str],
+            frac_x: list[float],
+            frac_y: list[float],
+            frac_z: list[float],
+            OutputFolder: str = '.',
+            **kwargs):
+    '''
+    Save the XSF file.
+
+    Parameters
+    ----------
+    FrameworkName : str
+        Name of the framework.
+    CellParameters : list
+        List of the cell parameters.
+    labels : list
+        List of the atomic labels.
+    frac_x : list
+        List of the atomic positions along the `a` vector.
+    frac_y : list
+        List of the atomic positions along the `b` vector.
+    frac_z : list
+        List of the atomic positions along the `c` vector.
+    OutputFolder : str
+        Path to the output folder. Default: `.`
+    '''
+
+    aseCell = Cell.fromcellpar(CellParameters)
+    # Get the cell parameters from cif file
+    CellMatrix = aseCell.tolist()
+
+    # Convert fractional coordinates to cartesian
+    cart_coords = aseCell.cartesian_positions(np.array([frac_x, frac_y, frac_z]).T)
+
+    xsf_file = dedent(f'''CRYSTAL
+PRIMVEC
+  {CellMatrix[0][0]:15.10f}    {CellMatrix[0][1]:15.10f}    {CellMatrix[0][2]:15.10f}
+  {CellMatrix[1][0]:15.10f}    {CellMatrix[1][1]:15.10f}    {CellMatrix[1][2]:15.10f}
+  {CellMatrix[2][0]:15.10f}    {CellMatrix[2][1]:15.10f}    {CellMatrix[2][2]:15.10f}
+PRIMCOORD    1
+      {len(labels)}   1
+''')
+    for j, atom in enumerate(labels):
+        xsf_file += ' {} {:15.10f}  {:15.10f}  {:15.10f}\n'.format(atom,
+                                                                   cart_coords[j][0],
+                                                                   cart_coords[j][1],
+                                                                   cart_coords[j][2])
+
+    with open(os.path.join(OutputFolder, f'{FrameworkName}.xsf'), 'w') as f:
+        f.write(xsf_file)
+
+
+def readCIF(FrameworkName: str,
+            OutputFolder: str = '.',
+            **kwargs):
+    """
+    Read the CIF file.
+
+    Parameters
+    ----------
+    FrameworkName : str
+        Name of the framework.
+    OutputFolder : str
+        Path to the output folder. Default: `.`
+    """
+
+    # Read the cif file and get the lattice parameters and atomic positions
+    cif_filename = os.path.join(OutputFolder, FrameworkName + '.cif')
+
+    cif = gemmi.cif.read_file(cif_filename).sole_block()
+
+    a = float(cif.find_value('_cell_length_a').split('(')[0])
+    b = float(cif.find_value('_cell_length_b').split('(')[0])
+    c = float(cif.find_value('_cell_length_c').split('(')[0])
+    beta = float(cif.find_value('_cell_angle_beta').split('(')[0])
+    gamma = float(cif.find_value('_cell_angle_gamma').split('(')[0])
+    alpha = float(cif.find_value('_cell_angle_alpha').split('(')[0])
+
+    CellParameters = [a, b, c, alpha, beta, gamma]
+
+    AtomicTypes = list(cif.find_values('_atom_site_type_symbol'))
+    PosX = np.array(cif.find_values('_atom_site_fract_x')).astype(float)
+    PosY = np.array(cif.find_values('_atom_site_fract_y')).astype(float)
+    PosZ = np.array(cif.find_values('_atom_site_fract_z')).astype(float)
+    try:
+        charges = np.array(cif.find_values('_atom_site_charge')).astype(float)
+        charge_type = 'DDEC'
+    except Exception:
+        charges = None
+        charge_type = None
+
+    return CellParameters, AtomicTypes, PosX, PosY, PosZ, charges, charge_type
+
+
+def saveCIF(FrameworkName: str,
+            cell: float,
+            labels: list[str],
+            frac_x: list[float],
+            frac_y: list[float],
+            frac_z: list[float],
+            charges: list[float] = None,
+            OutputFolder: str = '.',
+            **kwargs) -> None:
+    """
+    Save the CIF file.
+
+    Parameters
+    ----------
+    FrameworkName : str
+        Name of the framework.
+    cell : list
+        List of the cell parameters.
+    labels : list
+        List of the atomic labels.
+    frac_x : list
+        List of the atomic positions along the `a` vector.
+    frac_y : list
+        List of the atomic positions along the `b` vector.
+    frac_z : list
+        List of the atomic positions along the `c` vector.
+    charges : list
+        List of the atomic charges.
+    OutputFolder : str
+        Path to the output folder. Default: `.`
+    """
+    cif_file = dedent(f"""\
+data_{FrameworkName}
+_chemical_name_common                  '{FrameworkName}'
+_cell_length_a                          {cell[0]:10.5f}
+_cell_length_b                          {cell[1]:10.5f}
+_cell_length_c                          {cell[2]:10.5f}
+_cell_angle_alpha                       {cell[3]:10.5f}
+_cell_angle_beta                        {cell[4]:10.5f}
+_cell_angle_gamma                       {cell[5]:10.5f}
+
+_symmetry_cell_setting          triclinic
+_symmetry_space_group_name_Hall 'P 1'
+_symmetry_space_group_name_H-M  'P 1'
+_symmetry_Int_Tables_number     1
+
+_symmetry_equiv_pos_as_xyz 'x,y,z'
+
+loop_
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_charge
+""")
+
+    # Unique atoms in labes
+    symbols_number = {i: 0 for i in set(labels)}
+    symbols = []
+    for label in labels:
+        symbols_number[label] += 1
+        symbols.append(label + str(symbols_number[label]))
+
+    if charges is None:
+        for label, symbol, x, y, z in zip(labels, symbols, frac_x, frac_y, frac_z):
+            cif_file += "   {:3s}   {:6s}   {:15.10f}   {:15.10f}   {:15.10f}\n".format(
+                label, symbol, x, y, z
+                )
+    else:
+        for label, symbol, x, y, z, charge in zip(labels, symbols, frac_x, frac_y, frac_z, charges):
+            cif_file += "   {:3s}   {:6s}   {:15.10f}   {:15.10f}   {:15.10f}   {:10.7f}\n".format(
+                label, symbol, x, y, z, charge
+                )
+
+    with open(os.path.join(OutputFolder, f'{FrameworkName}.cif'), 'w') as f:
+        f.write(cif_file)
+
+
+def readGJF(FrameworkName: str, OutputFolder: str, **kwargs):
+    """
+    Read a GJF file.
+
+    Parameters
+    ----------
+    FrameworkName : str
+        Name of the framework.
+    OutputFolder : str
+        Path to the output folder. Default: `.`
+    """
+
+    with open(os.path.join(OutputFolder, FrameworkName + '.gjf'), 'r') as f:
+        lines = f.read().splitlines()
+
+    # Get the cell parameters
+    cellMatrix = []
+
+    for line in lines:
+        if 'Tv' in line:
+            cellMatrix.append(line.split()[1:].split())
+
+    cellMatrix = np.array(cellMatrix).astype(float)
+
+    atomLabels = []
+    carPositions = []
+    # Get the atomic labels
+    for line in lines:
+        if line.split()[0] in ATOMIC_NUMBER.keys():
+            atomLabels.append(line.split()[0])
+            carPositions.append(line.split()[1:])
+
+    carPositions = np.array(carPositions).astype(float)
+
+    # Convert cartesian coordinates to fractional
+    aseCell = Cell.frommatrix(cellMatrix)
+
+    # Get the cell matrix
+    cellParameters = aseCell.cellpar()
+
+    FracCoords = aseCell.get_scaled_positions(carPositions)
+
+    xPos, yPos, zPos = FracCoords.T
+
+    return cellParameters, atomLabels, xPos, yPos, zPos, None, None
+
+
+def saveGJF(FrameworkName: str,
+            CellParameters: float,
+            labels: list[str],
+            frac_x: list[float],
+            frac_y: list[float],
+            frac_z: list[float],
+            OutputFolder: str = '.',
+            **kwargs):
+    """
+    Save the GJF file.
+
+    Parameters
+    ----------
+    FrameworkName : str
+        Name of the framework.
+    cell : list
+        List of the cell parameters.
+    labels : list
+        List of the atomic labels.
+    frac_x : list
+        List of the atomic positions along the `a` vector.
+    frac_y : list
+        List of the atomic positions along the `b` vector.
+    frac_z : list
+        List of the atomic positions along the `c` vector.
+    OutputFolder : str
+        Path to the output folder. Default: `.`
+    """
+
+    aseCell = Cell.fromcellpar(CellParameters)
+    cellMatrix = aseCell.tolist()
+
+    # Get the cartesian coordinates
+    carCoords = aseCell.cartesian_positions(np.array([frac_x, frac_y, frac_z]).T)
+
+    gjf_file = dedent(f"""%chk={FrameworkName}.chk
+# pbepbe/3-21g/auto
+
+Title Card Required
+
+0 1
+""")
+    for i, atom in enumerate(labels):
+        gjf_file += f' {atom} {carCoords[i][0]:15.10f} {carCoords[i][1]:15.10f} {carCoords[i][2]:15.10f}\n'
+
+    for i in range(3):
+        gjf_file += f' Tv {cellMatrix[i][0]:15.10f} {cellMatrix[i][1]:15.10f} {cellMatrix[i][2]:15.10f}\n'
+
+
+def saveVibrationalVectors(OutputFolder, Frameworkname):
+    '''
+    Get the vibrational vectors from the CP2K output file.
+    '''
+
+    atom_labels, _, vibrations, _, _, _, freq_list = get_MoldenData(OutputFolder, Frameworkname)
+
+    # Get the cell parameters from cif file
+    CellParameters = get_CellParameters(Frameworkname + '.cif')
+    CellMatrix = Cell.fromcellpar(CellParameters).tolist()
+
+    os.makedirs(os.path.join(OutputFolder, 'VIBRATION_FILES'), exist_ok=True)
+
+    for i, vib in enumerate(vibrations):
+
+        axsf_filename = os.path.join(os.path.join(OutputFolder, 'VIBRATION_FILES'),
+                                     f'VIBRATIONS-{i}-{float(freq_list[i])}.axsf')
+        axsf_file = open(axsf_filename, 'w')
+
+        axsf_file.write('CRYSTAL\n')
+        axsf_file.write('PRIMVEC  \n')
+        axsf_file.write(f'  {CellMatrix[0][0]:15.10f}    {CellMatrix[0][1]:15.10f}    {CellMatrix[0][2]:15.10f}\n')
+        axsf_file.write(f'  {CellMatrix[1][0]:15.10f}    {CellMatrix[1][1]:15.10f}    {CellMatrix[1][2]:15.10f}\n')
+        axsf_file.write(f'  {CellMatrix[2][0]:15.10f}    {CellMatrix[2][1]:15.10f}    {CellMatrix[2][2]:15.10f}\n')
+        axsf_file.write('PRIMCOORD    1\n')
+        axsf_file.write(f'      {len(atom_labels)}   1\n')
+        for j, atom in enumerate(atom_labels):
+            axsf_file.write(f' {atom} {vib[j]}\n')
+
+        axsf_file.close()
+
+    return None
+
+
+def saveVibrationalChemicalJSON(OutputFolder, Frameworkname):
+
+    frequency, IR_intensity, RAMAN_intensity = get_vibrational_data(
+        os.path.join(OutputFolder, 'simulation_Vibrations.out')
+        )
+
+    atom_labels, atom_pos, _, modes, eigenVectors, _, _ = get_MoldenData(OutputFolder,
+                                                                         Frameworkname)
+
+    # Convert atom_labels to atom_number
+    atom_number = [gemmi.Element(atom).atomic_number for atom in atom_labels]
+
+    # Flatten the atom_pos list
+    atom_pos = [i for sublist in atom_pos for i in sublist]
+
+    # Get the cell parameters from cif file
+    CellParameters = get_CellParameters(Frameworkname + '.cif')
+    CellMatrix = Cell.fromcellpar(CellParameters).flatten().tolist()
+
+    formula = ' '.join([f'{atom}{atom_labels.count(atom)}' for atom in set(atom_labels)])
+
+    ChemJSON = {
+        "chemicalJson": 1,
+        "name": Frameworkname,
+        "formula": formula,
+        "unitCell": {
+            "a": CellParameters[0],
+            "b": CellParameters[1],
+            "c": CellParameters[2],
+            "alpha": CellParameters[3],
+            "beta":  CellParameters[4],
+            "gamma": CellParameters[5],
+            "cellVectors": CellMatrix
+        },
+        "atoms": {
+            "elements": {
+                "type": atom_labels,
+                "number": atom_number
+                },
+            "coords": {
+                "3d": atom_pos
+                }
+        },
+        'vibrations': {
+            'eigenVectors': eigenVectors,
+            'frequencies': list(frequency),
+            'intensities': list(IR_intensity),
+            'ramanIntensities': list(RAMAN_intensity),
+            'modes': modes
+        }
+        }
+
+    # Save ChemJSON as a json file
+    with open(os.path.join(OutputFolder, f'{Frameworkname}.cjson'), 'w') as f:
+        json.dump(ChemJSON, f, indent=4)

--- a/bin/modules/io_files.py
+++ b/bin/modules/io_files.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env -S python -B
 
-# Copyright IBM Corp. 2023
 # SPDX-License-Identifier: Apache2.0
 
 import os

--- a/bin/parse_charges.py
+++ b/bin/parse_charges.py
@@ -9,8 +9,8 @@ import argparse
 from modules.calculate_properties import (get_AtomicPositions,
                                           get_CellParameters,
                                           get_CM5AtomicCharges,
-                                          get_DDECAtomicCharges,
-                                          saveCIF)
+                                          get_DDECAtomicCharges)
+from modules.io_files import saveCIF
 
 # Required parameters
 parser = argparse.ArgumentParser(description='Create the Chargemol simulation input.')
@@ -60,20 +60,22 @@ CellParameters = get_CellParameters(cif_filename)
 AtomicTypes, PosX, PosY, PosZ = get_AtomicPositions(cif_filename)
 
 # Write the DDEC charges to file
-saveCIF(os.path.join(arg.output_folder, arg.FrameworkName + '_DDEC.cif'),
+saveCIF(arg.FrameworkName + '_DDEC',
         CellParameters,
         AtomicTypes,
         PosX,
         PosY,
         PosZ,
-        DDEC_Charges)
+        DDEC_Charges,
+        arg.output_folder)
 
 if arg.CM5:
     # Write the CM5 charges to file
-    saveCIF(os.path.join(arg.output_folder, arg.FrameworkName + '_CM5.cif'),
+    saveCIF(arg.FrameworkName + '_CM5',
             CellParameters,
             AtomicTypes,
             PosX,
             PosY,
             PosZ,
-            CM5_Charges)
+            CM5_Charges,
+            arg.output_folder)

--- a/bin/parse_vibrations.py
+++ b/bin/parse_vibrations.py
@@ -7,10 +7,8 @@ import os
 import argparse
 import numpy as np
 
-from modules.calculate_properties import (get_vibrational_data,
-                                          lorentzian,
-                                          saveVibrationalVectors,
-                                          saveChemicalJSON)
+from modules.calculate_properties import get_vibrational_data, lorentzian
+from modules.io_files import saveVibrationalVectors, saveVibrationalChemicalJSON
 
 # Required parameters
 parser = argparse.ArgumentParser(description='Create the Chargemol simulation input.')
@@ -68,7 +66,7 @@ np.savetxt(os.path.join(arg.output_folder, f'{arg.FrameworkName}_RAMAN_IR_Curve.
            delimiter=',')
 
 # Save the vibrations as cjson file
-saveChemicalJSON(arg.output_folder, arg.FrameworkName)
+saveVibrationalChemicalJSON(arg.output_folder, arg.FrameworkName)
 
 # Save the vibrational modes as AXSF files
 if arg.SaveVibrations:

--- a/bin/structure_optimization.py
+++ b/bin/structure_optimization.py
@@ -216,6 +216,13 @@ parser.add_argument('--MaxIterations',
                     required=False,
                     metavar='MAX_ITER',
                     help='Maximum number of optimization steps.')
+parser.add_argument('--TrustRadius',
+                    type=float,
+                    default=0.25,
+                    action='store',
+                    required=False,
+                    metavar='TRUST_RADIUS',
+                    help='Trust radius for the optimization.')
 parser.add_argument('--MaxDR',
                     type=float,
                     default=3e-2,
@@ -244,6 +251,13 @@ parser.add_argument('--RMSForce',
                     required=False,
                     metavar='RMS_DR',
                     help='Convergence criterion for the root mean square (RMS) force of the current configuration')
+parser.add_argument('--FixedAtoms',
+                    type='str',
+                    default=None,
+                    action='store',
+                    required=False,
+                    metavar='FIXED_ATOMS',
+                    help='List of atoms to be kept fixed during the optimization. Eg. 1..10,20,30..40')
 
 # Parse the arguments
 arg = parser.parse_args()
@@ -385,9 +399,15 @@ motion_dict = {
     ]
 }
 
+if arg.FixedAtoms is not None:
+    motion_dict['+fixed_atoms'] = {
+        "components_to_fix": "xyz",
+        "list": arg.FixedAtoms
+    }
+
 if arg.OptimizationType == 'cell_opt':
     motion_dict['+cell_opt'] = {
-        "+lbfgs": {"trust_radius": 0.25},
+        "+lbfgs": {"trust_radius": arg.TrustRadius},
         "optimizer": "lbfgs",
         "max_iter": arg.MaxIterations,
         "max_dr": arg.MaxDR,
@@ -403,7 +423,7 @@ if arg.OptimizationType == 'cell_opt':
 
 if arg.OptimizationType == 'geo_opt':
     motion_dict['+geo_opt'] = {
-        "+bfgs": {"trust_radius": 0.25},
+        "+bfgs": {"trust_radius": arg.TrustRadius},
         "max_iter": arg.MaxIterations,
         "max_dr": arg.MaxDR,
         "max_force": arg.MaxForce,

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: electronic-structure-experiment
+name: ese
 channels:
   - conda-forge
 dependencies:


### PR DESCRIPTION
This PR adds a new script called `convert_file.py` that allow the conversion between common file formats. 

Usage example:
```python
convert_file.py --FrameworkName ${FrameworkName} \
                --InputFormat "xsf" \
                --OutputFormat "cif" \
                ${PWD}
```
Currently the supported file formats are: `cif`, `gjf`, `xsf`, and `cjson`. 

This PR also adds the possibility to fix atoms during the optimization using the new option `--FixedAtoms` on `structure_optimization.py`
