### PR TITLE
Fix type value in structure_optimization.py

### DIFF
--- a/bin/structure_optimization.py
+++ b/bin/structure_optimization.py
@@ -252,7 +252,7 @@ parser.add_argument('--RMSForce',
                     metavar='RMS_DR',
                     help='Convergence criterion for the root mean square (RMS) force of the current configuration')
 parser.add_argument('--FixedAtoms',
-                    type='str',
+                    type=str,
                     default=None,
                     action='store',
                     required=False,


### PR DESCRIPTION
It was supposed to be type str and not a string 'str'.